### PR TITLE
MLX5 지원 추가

### DIFF
--- a/dpdk/src/eal.rs
+++ b/dpdk/src/eal.rs
@@ -303,6 +303,10 @@ impl Drop for PortInner {
         // Safety: foreign function.
         let ret = unsafe { dpdk_sys::rte_eth_dev_owner_unset(self.port_id, self.owner_id) };
         assert_eq!(ret, 0);
+        unsafe {
+            dpdk_sys::rte_eth_dev_stop(self.port_id);
+            dpdk_sys::rte_eth_dev_close(self.port_id);
+        }
         // TODO following code causes segmentation fault.  Its DPDK's bug that
         // `rte_eth_dev_owner_delete` does not check whether `rte_eth_devices[port_id].data` is
         // null.  Safety: foreign function.


### PR DESCRIPTION
이전에 @leeopop 님이 알려주신 방법대로, DPDK가 MLX5 PMD를 포함해 빌드가 된 것을 확인하고, 만약 그렇다면 rust-dpdk의 빌드에도 포함되게 수정했습니다.