### PR TITLE
Set rte_mempool size to 1023

### DIFF
--- a/dpdk/src/eal.rs
+++ b/dpdk/src/eal.rs
@@ -18,7 +18,7 @@ const MAGIC: &str = "be0dd4ab";
 
 pub const DEFAULT_TX_DESC: u16 = 128;
 pub const DEFAULT_RX_DESC: u16 = 128;
-pub const DEFAULT_RX_POOL_SIZE: usize = 1024;
+pub const DEFAULT_RX_POOL_SIZE: usize = 1023;
 pub const DEFAULT_RX_PER_CORE_CACHE: usize = 0;
 pub const DEFAULT_PACKET_DATA_LENGTH: usize = 2048;
 pub const DEFAULT_PROMISC: bool = true;


### PR DESCRIPTION

[From DPDK docs:](https://doc.dpdk.org/api/rte__mbuf_8h.html#a593921f13307803b94bbb4e0932db962 )

> The number of elements in the mbuf pool. The optimum size (in terms of memory usage) for a mempool is when n is a power of two minus one: n = (2^q - 1). 
